### PR TITLE
Working with nested path

### DIFF
--- a/adr_core_local_impl/src/adr_repo/mod.rs
+++ b/adr_core_local_impl/src/adr_repo/mod.rs
@@ -1229,6 +1229,33 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_seq_id_from_all_with_nested_dir() {
+        let mut paths = Vec::new();
+        paths.push(String::from("mypath/mysubpath/00000064-my-decision.adoc")); //this is should be the last seq id
+        paths.push(String::from("mypath/00000063-my-decision.adoc")); //this is should be the last seq id
+        paths.push(String::from("00000010-my-decision.adoc"));
+        paths.push(String::from("00000001-my-decision-594-full.adoc"));
+        paths.push(String::from(
+            "mypath/00000001/00000002-my-decision-594-full.adoc",
+        ));
+        paths.push(String::from("path/my-decision-full.adoc"));
+        paths.push(String::from("path/my-decision-543-0.adoc"));
+
+        let mut adr_vec = Vec::new();
+        for adr in paths.into_iter() {
+            adr_vec.push(super::Adr::from(
+                String::from("/adr/"),
+                String::from(adr),
+                String::from(ADOC_TMPL_NOTAG),
+            ));
+        }
+
+        adr_vec = super::sort_by_id(adr_vec);
+        let seq = super::get_last_seq_id(adr_vec);
+        assert_eq!(seq, 64);
+    }
+
+    #[test]
     fn test_format_decision_name() {
         let mut cfg: super::AdrToolConfig = adr_config::config::get_config();
         cfg.use_id_prefix = false;

--- a/adr_core_local_impl/src/adr_repo/mod.rs
+++ b/adr_core_local_impl/src/adr_repo/mod.rs
@@ -40,7 +40,7 @@ fn get_logger() -> slog::Logger {
 /// * `title`- the title of the ADR (specified by the user)
 /// *
 ///
-pub fn create_adr(cfg: AdrToolConfig, title: &str) -> io::Result<bool> {
+pub fn create_adr(cfg: AdrToolConfig, path: Option<&str>, title: &str) -> io::Result<bool> {
     let adr_template_dir = &cfg.adr_template_dir.as_str();
     let adr_template_file = &cfg.adr_template_file.as_str();
 
@@ -55,7 +55,14 @@ pub fn create_adr(cfg: AdrToolConfig, title: &str) -> io::Result<bool> {
         Ok(name) => name,
         Err(_why) => panic!(format!("Problem while formatting name [{}]", title)),
     };
-    let target_path = src_dir.join(format!("{}.adoc", name));
+    let target_path = match path {
+        None => src_dir.join(format!("{}.adoc", name)),
+        Some(val) => {
+            std::fs::create_dir_all(src_dir.join(val)).unwrap();
+            src_dir.join(val).join(format!("{}.adoc", name))
+        }
+    };
+
     let is_target_file = target_path.is_file();
     if !is_target_file {
         if path_to_template.exists() {
@@ -1350,7 +1357,7 @@ mod tests {
         fs::write(to.as_path(), ADOC_TMPL_NOTAG).unwrap();
 
         //test
-        let created = super::create_adr(config, "title of the ADR");
+        let created = super::create_adr(config, None, "title of the ADR");
         //
         assert!(created.unwrap());
         assert_eq!(true, src.path().exists());
@@ -1392,11 +1399,75 @@ mod tests {
         fs::write(to.as_path(), ADOC_TMPL_NOTAG).unwrap();
 
         //test
-        let created = super::create_adr(config, "title of the ADR");
+        let created = super::create_adr(config, None, "title of the ADR");
         //
         assert!(created.unwrap());
         assert_eq!(true, src.path().exists());
         assert_eq!(true, src.path().join("004-title-of-the-adr.adoc").exists());
+    }
+
+    #[test]
+    fn test_create_adr_w_nested_directories() {
+        let src = match TempDir::new("my_src_folder") {
+            Ok(src) => {
+                println!("Working with src dir [{}]", src.path().display());
+                src
+            }
+            Err(why) => {
+                println!("Unable to get src dir [{}]", why);
+                panic!(why);
+            }
+        };
+
+        //set config
+        let config = AdrToolConfig {
+            log_level: 6,
+            //adr_root_dir: format!("{}", src.path().display()),
+            adr_src_dir: format!("{}", src.path().display()),
+            adr_template_dir: format!("{}", src.path().display()),
+            adr_template_file: String::from("template.adoc"),
+            adr_search_index: format!("{}", src.path().display()),
+            use_id_prefix: true,
+            id_prefix_width: 3,
+        };
+
+        let to = PathBuf::from(src.path()).join("template.adoc");
+        fs::write(to.as_path(), ADOC_TMPL_NOTAG).unwrap();
+
+        //set a couple of already present files
+        let to = PathBuf::from(src.path()).join("001-ADR-1.adoc");
+        fs::write(to.as_path(), ADOC_TMPL_NOTAG).unwrap();
+        let to = PathBuf::from(src.path()).join("003-ADR-2.adoc");
+        fs::write(to.as_path(), ADOC_TMPL_NOTAG).unwrap();
+
+        //test
+        {
+            let created = super::create_adr(config.clone(), Some("sub_dir"), "title of the ADR");
+            //
+            assert!(created.unwrap());
+            assert_eq!(true, src.path().exists());
+            assert_eq!(
+                true,
+                src.path()
+                    .join("sub_dir")
+                    .join("004-title-of-the-adr.adoc")
+                    .exists()
+            );
+        }
+
+        {
+            let created = super::create_adr(config.clone(), Some("./sub_dir"), "title of the ADR");
+            //
+            assert!(created.unwrap());
+            assert_eq!(true, src.path().exists());
+            assert_eq!(
+                true,
+                src.path()
+                    .join("sub_dir")
+                    .join("005-title-of-the-adr.adoc")
+                    .exists()
+            );
+        }
     }
 
     #[test]

--- a/adr_core_local_impl/src/adr_repo/mod.rs
+++ b/adr_core_local_impl/src/adr_repo/mod.rs
@@ -50,7 +50,7 @@ pub fn create_adr(cfg: AdrToolConfig, title: &str) -> io::Result<bool> {
 
     let src_dir = Path::new(&cfg.adr_src_dir);
 
-    //specify lcargo buildast seq_id , the rest of the config (use_prefix and width can be get from the method)
+    //specify last seq_id , the rest of the config (use_prefix and width can be get from the method)
     let name = match format_decision_name(cfg.clone(), title) {
         Ok(name) => name,
         Err(_why) => panic!(format!("Problem while formatting name [{}]", title)),

--- a/adr_core_local_impl/tests/create_adr.rs
+++ b/adr_core_local_impl/tests/create_adr.rs
@@ -54,7 +54,7 @@ mod helper {
                 .unwrap(),
         );
 
-        Ok(adr_core::adr_repo::create_adr(cfg, name).unwrap())
+        Ok(adr_core::adr_repo::create_adr(cfg, None, name).unwrap())
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -250,6 +250,14 @@ fn main() {
                                 .takes_value(true)
                                 .required(true)
                                 .help("Give the name of your Decision Record"),
+                        )
+                        .arg(
+                            Arg::with_name("path")
+                                .short("p")
+                                .long("path")
+                                .takes_value(true)
+                                .required(false)
+                                .help("Specify relative path (nested directories)"),
                         ),
                 )
                 .subcommand(
@@ -357,6 +365,7 @@ fn main() {
                 if matches.is_present("name") {
                     adr_core::adr_repo::create_adr(
                         adr_config::config::get_config(),
+                        matches.value_of("path"),
                         matches.value_of("name").unwrap(),
                     )
                     .unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -244,12 +244,12 @@ fn main() {
                         .about("Creates a new Decision Record")
                         .version("0.1.0")
                         .arg(
-                            Arg::with_name("name")
-                                .short("n")
-                                .long("name")
+                            Arg::with_name("title")
+                                .short("t")
+                                .long("title")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Give the name of your Decision Record"),
+                                .help("Give the title of your Decision Record"),
                         )
                         .arg(
                             Arg::with_name("path")
@@ -362,11 +362,11 @@ fn main() {
         }
         ("lf", Some(matches)) => match matches.subcommand() {
             ("new", Some(matches)) => {
-                if matches.is_present("name") {
+                if matches.is_present("title") {
                     adr_core::adr_repo::create_adr(
                         adr_config::config::get_config(),
                         matches.value_of("path"),
-                        matches.value_of("name").unwrap(),
+                        matches.value_of("title").unwrap(),
                     )
                     .unwrap();
                 }


### PR DESCRIPTION
Just add a test to ensure ID is "working" in case the ADR is in sub directories.

In this case, the ID is unique whatever the directory tree structure.